### PR TITLE
[PS-36] do not clobber existing keys

### DIFF
--- a/service-utils/gen-ecdsa.sh
+++ b/service-utils/gen-ecdsa.sh
@@ -1,30 +1,49 @@
-# First argument sets the location of /etc directory.
-path_to_etc=${1:?"Path to /etc must be the first parameter."}
+set -e  # Crash on any error.
 
-shift  # Cut off $1 so that the rest of $@ is a list of names.
+# First argument sets the location of /etc directory.
+path_to_etc=${1:?"An absolute path to /etc must be the first parameter."}
+
+shift  # Cut off $1 so that the rest of $@ is the list of names.
 if [ -z "$*" ]; then
     echo "No service names passed!"
     exit 1
 fi
 
+# We do not want to bring `make` to every image and then play with makefiles.
+# Instead we check the presence of the expected files ourselves.
+
+KEYS_DIR=${path_to_etc}/creds/services/keys
+CERTS_DIR=${path_to_etc}/creds/services/certs
+
 TMP="tmp-gen-ecsda-$$"
 
 mkdir ${TMP} && cd ${TMP}
 
-echo "Setting up credential directory structure..."
-mkdir -p $path_to_etc/creds/services/keys
-mkdir -p $path_to_etc/creds/services/certs
+echo "Making sure credential directory structure is present..."
+mkdir -p ${KEYS_DIR}
+mkdir -p ${CERTS_DIR}
+
+already_present_names=""
 
 for server_name in "$@"
 do
-    echo "Generating ECDSA private key for ${server_name}..."
-    openssl ecparam -name secp256k1 -genkey -noout -out $server_name-signing-key.pem
-    cp $server_name-signing-key.pem $path_to_etc/creds/services/keys
+    # Check if we have any work to do.
+    if [ -f ${KEYS_DIR}/${server_name}-signing-key.pem ] && [ -f ${CERTS_DIR}/${server_name}-signing-pubkey.pem ]; then
+        already_present_names="${already_present_names} ${server_name}"
+    else
+        echo "Generating ECDSA private key for ${server_name}..."
+        openssl ecparam -name secp256k1 -genkey -noout -out ${server_name}-signing-key.pem
+        cp ${server_name}-signing-key.pem ${KEYS_DIR}
 
-    echo "Generating ECDSA public key for ${server_name}..."
-    openssl ec -in $server_name-signing-key.pem -pubout -out $server_name-signing-pubkey.pem
-    cp $server_name-signing-pubkey.pem $path_to_etc/creds/services/certs
+        echo "Generating ECDSA public key for ${server_name}..."
+        openssl ec -in ${server_name}-signing-key.pem -pubout -out ${server_name}-signing-pubkey.pem
+        cp ${server_name}-signing-pubkey.pem ${CERTS_DIR}
+    fi
 done
+
+if [ "${already_present_names}" ]; then
+    echo "Keys already present for:${already_present_names}."
+fi
 
 
 

--- a/service-utils/gen-ecdsa.sh
+++ b/service-utils/gen-ecdsa.sh
@@ -1,24 +1,33 @@
-path_to_etc=/etc
+# First argument sets the location of /etc directory.
+path_to_etc=${1:?"Path to /etc must be the first parameter."}
 
-mkdir tmp && cd tmp
+shift  # Cut off $1 so that the rest of $@ is a list of names.
+if [ -z "$*" ]; then
+    echo "No service names passed!"
+    exit 1
+fi
+
+TMP="tmp-gen-ecsda-$$"
+
+mkdir ${TMP} && cd ${TMP}
 
 echo "Setting up credential directory structure..."
 mkdir -p $path_to_etc/creds/services/keys
 mkdir -p $path_to_etc/creds/services/certs
 
-for server_name in "${@:1}"
+for server_name in "$@"
 do
-    echo "Generating ECDSA private key..."
+    echo "Generating ECDSA private key for ${server_name}..."
     openssl ecparam -name secp256k1 -genkey -noout -out $server_name-signing-key.pem
     cp $server_name-signing-key.pem $path_to_etc/creds/services/keys
 
-    echo "Generating ECDSA public key..."
+    echo "Generating ECDSA public key for ${server_name}..."
     openssl ec -in $server_name-signing-key.pem -pubout -out $server_name-signing-pubkey.pem
     cp $server_name-signing-pubkey.pem $path_to_etc/creds/services/certs
 done
 
 
 
-echo "Cleaning up..."
+echo "Cleaning up ${TMP}..."
 cd ..
-rm -rf tmp
+rm -rf ${TMP}

--- a/service-utils/gen-ssl.sh
+++ b/service-utils/gen-ssl.sh
@@ -2,7 +2,7 @@
 set -e
 
 # First argument sets the location of /etc directory.
-path_to_etc=${1:?"Path to /etc must be the first parameter."}
+path_to_etc=${1:?"An absolute path to /etc must be the first parameter."}
 
 shift  # Cut off $1 so that the rest of $@ is a list of names.
 if [ -z "$*" ]; then
@@ -10,54 +10,120 @@ if [ -z "$*" ]; then
     exit 1
 fi
 
-# Allow environment to override openssl config path.
-openssl_conf_path=${CT_OPENSSL_CONF_PATH:-/etc/ssl/ct-openssl.conf}
+# Allow environment to override openssl config file.
+openssl_conf_file=${CT_OPENSSL_CONF_FILE:-/etc/ssl/ct-openssl.conf}
+if [ ! -f  "${openssl_conf_file}" ]; then
+    echo "No openssl config file at '${openssl_conf_file}'."
+    exit 1
+fi
 
-echo "Setting up credential directory structure..."
-mkdir -p $path_to_etc/creds/root/certs
-mkdir -p $path_to_etc/creds/root/keys
-mkdir -p $path_to_etc/creds/services/certs
-mkdir -p $path_to_etc/creds/services/keys
+ROOT_CERTS=${path_to_etc}/creds/root/certs
+ROOT_KEYS=${path_to_etc}/creds/root/keys
+SVC_CERTS=${path_to_etc}/creds/services/certs
+SVC_KEYS=${path_to_etc}/creds/services/keys
 
-TMP="tmp-gen-ssl-$$"
+TMP="tmp-gen-ssl-$$"  # Temporary work dir name.
 
-mkdir ${TMP} && cd ${TMP}
+enter_tmp_dir() {
+    mkdir ${TMP} && cd ${TMP}
+}
 
-echo "Generating root certs..."
-openssl genrsa -passout pass:1111 -des3 -out ca.key.pem 4096
+leave_tmp_dir() {
+    echo "Cleaning up ${TMP}..."
+    cd ..
+    rm -rf ${TMP}
+}
 
-openssl req -passin pass:1111 -new -x509 -days 7300 -key ca.key.pem -out ca.cert.pem -subj  "/C=FR/ST=Paris/L=Paris/O=Test/OU=Test/CN=root"
+echo "Making sure credential directory structure is present..."
+mkdir -p ${ROOT_CERTS}
+mkdir -p ${ROOT_KEYS}
+mkdir -p ${SVC_CERTS}
+mkdir -p ${SVC_KEYS}
 
-echo "Generating intermediate certs..."
-openssl genrsa -passout pass:1111 -des3 -out ca-intermediate.key.pem 4096
+##
+# CA generation.
 
-openssl req -passin pass:1111 -new -key ca-intermediate.key.pem -out ca-intermediate.csr -subj  "/C=FR/ST=Paris/L=Paris/O=Test/OU=Test/CN=intermediate"
+# Check if we even have any work to do. (We don't want `make` run in every container.)
+# See `cp` statements below for the logic of the names.
+ALL_FOUND="yes"
+(
+    [ -f ${ROOT_KEYS}/ca-intermediate.key.pem ] &&
+    [ -f ${ROOT_KEYS}/ca.key.pem ] &&
+    [ -f ${ROOT_CERTS}/ca.cert.pem ] &&
+    [ -f ${ROOT_CERTS}/ca-intermediate.cert.pem ]
+) || ALL_FOUND="no"
 
-openssl x509 -req -passin pass:1111 -days 365 -extensions v3_intermediate_ca -extfile $openssl_conf_path -in ca-intermediate.csr -CA ca.cert.pem -CAkey ca.key.pem -set_serial 01 -out ca-intermediate.cert.pem
+if [ ${ALL_FOUND} = "yes" ]; then
+    echo "Root keys and certificates are already present."
+else
+    # NOTE: Since we're re-generating the CA, any certs and keys lying around are no more valid.
+    # Remove them.
+    echo "Generating root certs."
+    
+    echo "Removing any pre-existing keys and certs."
+    rm -rf ${SVC_CERTS}/*
+    rm -rf ${SVC_KEYS}/*
 
-openssl rsa -passin pass:1111 -in ca-intermediate.key.pem -out ca-intermediate.key.pem
+    enter_tmp_dir
 
-cp ca-intermediate.key.pem $path_to_etc/creds/root/keys/ca-intermediate.key.pem
-cp ca.key.pem $path_to_etc/creds/root/keys/ca.key.pem
-cp ca.cert.pem  $path_to_etc/creds/root/certs/ca.cert.pem
-cp ca-intermediate.cert.pem  $path_to_etc/creds/root/certs/ca-intermediate.cert.pem
+    openssl genrsa -passout pass:1111 -des3 -out ca.key.pem 4096
 
-for server_name in "$@"
-do
-    echo "Generating service certs for ${server_name}..."
-    openssl genrsa -passout pass:1111 -des3 -out $server_name.key.pem 4096
+    openssl req -passin pass:1111 -new -x509 -days 7300 -key ca.key.pem -out ca.cert.pem \
+            -subj "/C=FR/ST=Paris/L=Paris/O=Test/OU=Test/CN=root"
 
-    openssl req -passin pass:1111 -new -key $server_name.key.pem -out $server_name.csr -subj  "/C=FR/ST=Paris/L=Paris/O=Test/OU=Test/CN=${server_name}.local.clicktherapeutics.com"
+    echo "Generating intermediate certs..."
+    openssl genrsa -passout pass:1111 -des3 -out ca-intermediate.key.pem 4096
 
-    openssl x509 -req -passin pass:1111 -days 365 -in $server_name.csr -CA ca-intermediate.cert.pem -CAkey ca-intermediate.key.pem -set_serial 01 -out $server_name.cert.pem
+    openssl req -passin pass:1111 -new -key ca-intermediate.key.pem -out ca-intermediate.csr \
+            -subj "/C=FR/ST=Paris/L=Paris/O=Test/OU=Test/CN=intermediate"
 
-    openssl rsa -passin pass:1111 -in $server_name.key.pem -out $server_name.key.pem
+    openssl x509 -req -passin pass:1111 -days 365 -extensions v3_intermediate_ca -extfile ${openssl_conf_file} \
+            -in ca-intermediate.csr -CA ca.cert.pem -CAkey ca.key.pem -set_serial 01 -out ca-intermediate.cert.pem
 
-    echo "copying files to /etc/creds dir"
-    cat $server_name.cert.pem ca-intermediate.cert.pem ca.cert.pem > $path_to_etc/creds/services/certs/$server_name-chain.cert.pem
-    cp $server_name.key.pem $path_to_etc/creds/services/keys
+    openssl rsa -passin pass:1111 -in ca-intermediate.key.pem -out ca-intermediate.key.pem
+
+    cp ca-intermediate.key.pem ${ROOT_KEYS}/ca-intermediate.key.pem
+    cp ca.key.pem ${ROOT_KEYS}/ca.key.pem
+    cp ca.cert.pem  ${ROOT_CERTS}/ca.cert.pem
+    cp ca-intermediate.cert.pem  ${ROOT_CERTS}/ca-intermediate.cert.pem
+
+    leave_tmp_dir
+fi
+
+##
+# Server keys generation.
+
+# NOTE: if CA generation above was run, all keys were removed.
+# If it was not, we may need to generate just some extra service keys using the existing root cert.
+
+already_present_names=""
+
+for server_name in "$@"; do
+    if [ -f ${SVC_KEYS}/${server_name}.key.pem ] && [ ${SVC_CERTS}/${server_name}-chain.cert.pem ]; then
+        already_present_names="${already_present_names} ${server_name}"
+    else
+        enter_tmp_dir
+
+        echo "Generating service certs for ${server_name}."
+        openssl genrsa -passout pass:1111 -des3 -out ${server_name}.key.pem 4096
+
+        openssl req -passin pass:1111 -new -key ${server_name}.key.pem -out ${server_name}.csr \
+                -subj  "/C=FR/ST=Paris/L=Paris/O=Test/OU=Test/CN=${server_name}.local.clicktherapeutics.com"
+
+        openssl x509 -req -passin pass:1111 -days 365 -in ${server_name}.csr \
+                -CA ${ROOT_CERTS}/ca-intermediate.cert.pem -CAkey ${ROOT_KEYS}/ca-intermediate.key.pem \
+                -set_serial 01 -out ${server_name}.cert.pem
+
+        openssl rsa -passin pass:1111 -in ${server_name}.key.pem -out ${server_name}.key.pem
+
+        echo "copying files to /etc/creds dir"
+        cat ${server_name}.cert.pem ${ROOT_CERTS}/ca-intermediate.cert.pem ${ROOT_CERTS}/ca.cert.pem > ${SVC_CERTS}/${server_name}-chain.cert.pem
+        cp ${server_name}.key.pem ${SVC_KEYS}
+
+        leave_tmp_dir
+    fi
 done
 
-echo "Cleaning up ${TMP}..."
-cd ..
-rm -rf ${TMP}
+if [ "${already_present_names}" ]; then
+    echo "Certs and keys are already present for:${already_present_names}."
+fi

--- a/service-utils/setup
+++ b/service-utils/setup
@@ -1,12 +1,31 @@
 #/bin/sh -e
-version_tag=$1
+# Note: the ${var:...} stuff works both in bash and in Alpine's ash.
 
-gen_ecdsa_path=/usr/local/bin/ct-gen-ecdsa.sh
-gen_ssl_path=/usr/local/bin/ct-gen-ssl.sh
+version_tag=${1:?"Version tag must be passed as \$1."}
 
-curl https://raw.githubusercontent.com/clicktherapeutics/ct-public-utils/$version_tag/service-utils/gen-ecdsa.sh > $gen_ecdsa_path
-curl https://raw.githubusercontent.com/clicktherapeutics/ct-public-utils/$version_tag/service-utils/gen-ssl.sh > $gen_ssl_path
-curl https://raw.githubusercontent.com/clicktherapeutics/ct-public-utils/$version_tag/service-utils/ct-openssl.conf > /etc/ssl/ct-openssl.conf
+# Install scripts to target dir in $2, if given.
+TARGET_DIR=${2:-/usr/local/bin}
+
+# Install SSL conf to $3, if given.
+SSL_CONF_DIR=${3:-/etc/ssl}
+
+if [ ! -d "${TARGET_DIR}" ]; then
+    echo "Cannot find target directory '${TARGET_DIR}'."
+    exit 1
+fi
+
+if [ ! -d "${SSL_CONF_DIR}" ]; then
+    echo "Cannot find SSL configuration directory '${SSL_CONF_DIR}'."
+    exit 1
+fi
+
+SOURCE_URI="https://raw.githubusercontent.com/clicktherapeutics/ct-public-utils/${version_tag}/service-utils"
+gen_ecdsa_path=${TARGET_DIR}/ct-gen-ecdsa.sh
+gen_ssl_path=${TARGET_DIR}/ct-gen-ssl.sh
+
+curl ${SOURCE_URI}/gen-ecdsa.sh > $gen_ecdsa_path
+curl ${SOURCE_URI}/gen-ssl.sh > $gen_ssl_path
+curl ${SOURCE_URI}/ct-openssl.conf > ${SSL_CONF_DIR}/ct-openssl.conf
 
 chmod 744 $gen_ecdsa_path
 chmod 744 $gen_ssl_path


### PR DESCRIPTION
Makes cert / key generation scripts check and preserve existing keys, in a make-like fashion.
Improves code here and there.

Done as a part of [PS-36](https://goclick.atlassian.net/browse/PS-36); needed to let changes to the `auth` functional tests to work.